### PR TITLE
feat: 닉네임 설정 및 프로필 이미지 변경 API

### DIFF
--- a/src/main/java/com/likelion/lookie/common/exception/user/UserErrorCode.java
+++ b/src/main/java/com/likelion/lookie/common/exception/user/UserErrorCode.java
@@ -12,8 +12,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
-    NO_USER_INFO(HttpStatus.BAD_REQUEST, "400", "사용자 정보가 존재하지 않습니다.")
-    ;
+    NO_USER_INFO(HttpStatus.BAD_REQUEST, "400", "사용자 정보가 존재하지 않습니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "이미 사용 중인 닉네임입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/likelion/lookie/common/oauth/dto/OidcDecodePayload.java
+++ b/src/main/java/com/likelion/lookie/common/oauth/dto/OidcDecodePayload.java
@@ -7,7 +7,7 @@ public record OidcDecodePayload(
         String iss,
         String aud,
         String sub,
-        String nickname,
+        String name,
         String picture,
         String email
 ) {
@@ -17,7 +17,7 @@ public record OidcDecodePayload(
         claims.put("iss", iss);
         claims.put("aud", aud);
         claims.put("sub", sub);
-        claims.put("nickname", nickname);
+        claims.put("nickname", name);
         claims.put("picture", picture);
         claims.put("email", email);
         return claims;

--- a/src/main/java/com/likelion/lookie/common/oauth/service/KakaoLoginService.java
+++ b/src/main/java/com/likelion/lookie/common/oauth/service/KakaoLoginService.java
@@ -57,7 +57,7 @@ public class KakaoLoginService extends OidcUserService {
                 .map(existingUser -> {
                     // 업데이트할 정보가 있다면 업데이트
                     existingUser.updateProfile(
-                            oidcDecodePayload.nickname(),
+                            oidcDecodePayload.name(),
                             oidcDecodePayload.email(),
                             oidcDecodePayload.picture()
                     );

--- a/src/main/java/com/likelion/lookie/controller/user/controller/UserController.java
+++ b/src/main/java/com/likelion/lookie/controller/user/controller/UserController.java
@@ -1,13 +1,12 @@
 package com.likelion.lookie.controller.user.controller;
 
+import com.likelion.lookie.controller.user.dto.OnboardingRequestDto;
 import lombok.RequiredArgsConstructor;
 import com.likelion.lookie.common.exception.ApplicationResponse;
 import com.likelion.lookie.controller.user.dto.UserInfoDTO;
 import com.likelion.lookie.service.user.UserService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +20,14 @@ public class UserController implements UserControllerDocs {
             @AuthenticationPrincipal UserInfoDTO userInfoDTO
     ) {
         return ApplicationResponse.ok(userInfoDTO);
+    }
+
+    @PostMapping
+    public ApplicationResponse<String> createUser(
+            @AuthenticationPrincipal UserInfoDTO userInfoDTO,
+            @RequestBody OnboardingRequestDto requestDto
+    ) {
+        return ApplicationResponse.ok(userService.createUser(userInfoDTO, requestDto));
     }
 
 }

--- a/src/main/java/com/likelion/lookie/controller/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/likelion/lookie/controller/user/controller/UserControllerDocs.java
@@ -1,5 +1,6 @@
 package com.likelion.lookie.controller.user.controller;
 
+import com.likelion.lookie.controller.user.dto.OnboardingRequestDto;
 import com.likelion.lookie.controller.user.dto.UserInfoDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import com.likelion.lookie.common.exception.ApplicationResponse;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "User", description = "User API")
 public interface UserControllerDocs {
@@ -24,4 +26,18 @@ public interface UserControllerDocs {
     @Operation(summary = "사용자 정보 제공", description = "사용자 정보 전달 API")
     ApplicationResponse<UserInfoDTO> getUserInfo(
             @AuthenticationPrincipal UserInfoDTO userInfoDTO);
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @Operation(summary = "온보딩-닉네임 설정", description = "닉네임 설정 및 프로필 사진 변경")
+    ApplicationResponse<String> createUser(
+            @AuthenticationPrincipal UserInfoDTO userInfoDTO,
+            @RequestBody OnboardingRequestDto requestDto);
+
+
 }

--- a/src/main/java/com/likelion/lookie/controller/user/dto/OnboardingRequestDto.java
+++ b/src/main/java/com/likelion/lookie/controller/user/dto/OnboardingRequestDto.java
@@ -1,0 +1,7 @@
+package com.likelion.lookie.controller.user.dto;
+
+public record OnboardingRequestDto(
+        String nickname,
+        String filePath
+) {
+}

--- a/src/main/java/com/likelion/lookie/entity/User.java
+++ b/src/main/java/com/likelion/lookie/entity/User.java
@@ -24,18 +24,30 @@ public class User extends BaseEntity {
     // 새로운 사용자를 생성하는 팩토리 메서드
     public static User createSocialUser(OidcDecodePayload payload) {
         User user = new User();
-        user.nickname = payload.sub();
-        user.name = payload.nickname();
+        user.subId = payload.sub();
+        user.name = payload.name();
         user.email = payload.email();
         user.picture = payload.picture();
         return user;
     }
 
     // 사용자 프로필을 업데이트하는 메서드
-    public void updateProfile(String nickname, String email, String profileImage) {
-        this.name = nickname;
+    public void updateProfile(String name, String email, String profileImage) {
+        this.name = name;
         this.email = email;
         this.picture = profileImage;
     }
+
+
+    // 닉네임 업데이트 메서드
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    // 파일 경로 업데이트 메서드
+    public void updateFilePath(String filePath) {
+        this.picture = filePath;
+    }
+
 
 }

--- a/src/main/java/com/likelion/lookie/repository/UserRepository.java
+++ b/src/main/java/com/likelion/lookie/repository/UserRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    boolean existsByNickname(String nickname); // 닉네임 중복 체크
+
     Optional<User> findBySubId(String subId);
 
     Optional<User> findByEmail(String email);

--- a/src/main/java/com/likelion/lookie/service/user/UserService.java
+++ b/src/main/java/com/likelion/lookie/service/user/UserService.java
@@ -2,6 +2,7 @@ package com.likelion.lookie.service.user;
 
 import com.likelion.lookie.common.exception.user.UserCustomException;
 import com.likelion.lookie.common.exception.user.UserErrorCode;
+import com.likelion.lookie.controller.user.dto.OnboardingRequestDto;
 import com.likelion.lookie.controller.user.dto.UserInfoDTO;
 import com.likelion.lookie.entity.User;
 import com.likelion.lookie.repository.UserRepository;
@@ -23,4 +24,24 @@ public class UserService {
     }
 
 
+    public String createUser(UserInfoDTO userInfoDTO, OnboardingRequestDto requestDto) {
+
+        boolean nicknameExists = userRepository.existsByNickname(requestDto.nickname());
+        if (nicknameExists) {
+            throw new UserCustomException(UserErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        User user = userRepository.findByEmail(userInfoDTO.email())
+                .orElseThrow(() -> new UserCustomException(UserErrorCode.NO_USER_INFO));
+
+        user.updateNickname(requestDto.nickname());
+
+        if (requestDto.filePath() != null) {
+            user.updateFilePath(requestDto.filePath());
+        }
+
+        userRepository.save(user);
+
+        return "User information successfully updated.";
+    }
 }


### PR DESCRIPTION
일단 닉네임 가능 여부는 프론트에서 체크하는 것으로 가정하고 구현했습니다.

닉네임 중복은 안되는 것으로 구현했습니다.

프론트에서 해줘야할 것들을 정리하자면,

1. /api/v1/file로 presigned Url과 filePath를 받는다. (이때, prefix는 /images/profile)
2. presigned Url로 이미지 파일을 put한다. (200ok가 오면 성공했다는 의미)
3. filePath를 /api/v1/user의 request body - filePath에 넣는다.